### PR TITLE
Various cleanups from anguslees@

### DIFF
--- a/task-scheduler-rust/src/apply.rs
+++ b/task-scheduler-rust/src/apply.rs
@@ -2,11 +2,14 @@ use std::{
     io,
     io::{Error, ErrorKind},
     string::String,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
-use async_std::{sync::Arc, task};
-use crossbeam_channel::{self, after, select, unbounded};
+use tokio::select;
+use tokio::sync::mpsc;
+use tokio::task::{self, JoinHandle};
+use tokio::time::timeout;
 
 use crate::echo;
 use crate::id;
@@ -23,167 +26,101 @@ impl Request {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct Applier {
     request_timeout: Duration,
 
-    request_id_generator: Arc<id::Generator>,
+    request_id_generator: id::Generator,
     notifier: Arc<notify::Notifier>,
 
-    request_tx: crossbeam_channel::Sender<(u64, Request)>,
-    request_rx: crossbeam_channel::Receiver<(u64, Request)>,
-
-    stop_tx: crossbeam_channel::Sender<()>,
-    stop_rx: crossbeam_channel::Receiver<()>,
-
-    done_tx: crossbeam_channel::Sender<()>,
-    done_rx: crossbeam_channel::Receiver<()>,
-
-    echo_manager: Arc<echo::Manager>,
+    request_tx: mpsc::UnboundedSender<(u64, Request)>,
+    stop_tx: mpsc::Sender<()>,
 }
 
 impl Applier {
-    pub fn new(req_timeout: Duration) -> Self {
+    pub fn new(req_timeout: Duration) -> (Self, JoinHandle<io::Result<()>>) {
         let member_id = rand::random::<u64>();
 
-        let (request_ch_tx, request_ch_rx) = unbounded();
-        let (stop_ch_tx, stop_ch_rx) = unbounded();
-        let (done_ch_tx, done_ch_rx) = unbounded();
+        let (request_ch_tx, request_ch_rx) = mpsc::unbounded_channel();
+        let (stop_ch_tx, stop_ch_rx) = mpsc::channel(1);
 
-        Self {
-            request_timeout: req_timeout,
+        let notifier = Arc::new(notify::Notifier::new());
+        let echo_manager = echo::Manager::new();
 
-            request_id_generator: Arc::new(id::Generator::new(member_id, Instant::now().elapsed())),
-            notifier: Arc::new(notify::Notifier::new()),
+        let notifier_clone = notifier.clone();
 
-            request_tx: request_ch_tx,
-            request_rx: request_ch_rx,
-            stop_tx: stop_ch_tx,
-            stop_rx: stop_ch_rx,
-            done_tx: done_ch_tx,
-            done_rx: done_ch_rx,
+        let handle = task::spawn(async move {
+            apply_async(notifier_clone, request_ch_rx, stop_ch_rx, echo_manager).await
+        });
 
-            echo_manager: Arc::new(echo::Manager::new()),
-        }
-    }
+        (
+            Self {
+                request_timeout: req_timeout,
 
-    pub async fn start(&self) -> io::Result<()> {
-        task::spawn(apply_async(
-            self.notifier.clone(),
-            self.request_rx.clone(),
-            self.stop_rx.clone(),
-            self.done_tx.clone(),
-            self.echo_manager.clone(),
-        ));
-        // async runtimes are cooperative, picking a thread and may compute forever
-        // so, multiple workers may block up the whole runtime
-        // manually call "yield" or "yield_now" to allow newly-spawned task to execute first
-        // ref. https://docs.rs/tokio/1.6.0/tokio/task/fn.yield_now.html
-        task::yield_now().await;
+                request_id_generator: id::Generator::new(member_id, Instant::now().elapsed()),
+                notifier,
 
-        Ok(())
+                request_tx: request_ch_tx,
+                stop_tx: stop_ch_tx,
+            },
+            handle,
+        )
     }
 
     pub async fn stop(&self) -> io::Result<()> {
         println!("stopping applier");
-        match self.stop_tx.send(()) {
-            Ok(_) => println!("sent stop_tx"),
+
+        match self.stop_tx.send(()).await {
+            Ok(()) => println!("sent stop_tx"),
             Err(e) => {
-                println!("failed to send stop_tx {}", e);
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("failed to send {}", e),
-                ));
+                println!("failed to send stop_tx: {}", e);
+                return Err(Error::new(ErrorKind::Other, format!("failed to send")));
             }
         }
-        match self.done_rx.recv() {
-            Ok(_) => println!("received done_rx"),
-            Err(e) => {
-                println!("failed to receive done_rx {}", e);
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("failed to recv {}", e),
-                ));
-            }
-        };
 
-        println!("stopped applier");
         Ok(())
     }
 
     pub async fn apply(&self, req: Request) -> io::Result<String> {
         let req_id = self.request_id_generator.next();
-
-        let resp_rx;
-        match self.notifier.register(req_id) {
-            Ok(ch) => resp_rx = ch,
-            Err(e) => return Err(e),
-        }
+        let resp_rx = self.notifier.register(req_id)?;
 
         match self.request_tx.send((req_id, req)) {
             Ok(_) => println!("scheduled a request"),
             Err(e) => {
-                match self
-                    .notifier
-                    .trigger(req_id, format!("failed to schedule {} {}", req_id, e))
-                {
-                    Ok(_) => {}
-                    Err(e) => return Err(e),
-                }
+                self.notifier
+                    .trigger(req_id, format!("failed to schedule {} {}", req_id, e))?;
             }
         }
 
-        let timeout = after(self.request_timeout);
-        select! {
-            recv(resp_rx) -> msg => match msg {
-                Ok(rs) => Ok(rs),
-                Err(e) => Err(Error::new(
-                        ErrorKind::Other,
-                        format!("failed to apply {}", e),
-                    ))
-            },
-            recv(timeout) -> _ => return Err(Error::new(ErrorKind::Other, "timeout"))
-        }
+        let msg = timeout(self.request_timeout, resp_rx)
+            .await
+            .map_err(|_| Error::new(ErrorKind::Other, "timeout"))?;
+
+        let rs = msg.map_err(|e| Error::new(ErrorKind::Other, format!("failed to apply {}", e)))?;
+
+        Ok(rs)
     }
 }
 
 pub async fn apply_async(
     notifier: Arc<notify::Notifier>,
-    request_rx: crossbeam_channel::Receiver<(u64, Request)>,
-    stop_rx: crossbeam_channel::Receiver<()>,
-    done_tx: crossbeam_channel::Sender<()>,
-    echo_manager: Arc<echo::Manager>,
+    mut request_rx: mpsc::UnboundedReceiver<(u64, Request)>,
+    mut stop_rx: mpsc::Receiver<()>,
+    mut echo_manager: echo::Manager,
 ) -> io::Result<()> {
     println!("running apply routine");
     'outer: loop {
         // select either
         // receive either from "stop_rx" or "request_rx"
-        let req_id;
-        let req;
-        select! {
-            recv(request_rx) -> pair => {
-                match pair {
-                    Ok(v) => {
-                        req_id = v.0;
-                        req = v.1;
-                    },
-                    Err(e) => {
-                        println!("failed to receive request {}", e);
-                        continue 'outer;
-                    }
-                }
-            }
-            recv(stop_rx) -> _ => {
+        let (req_id, req) = select! {
+            Some(v) = request_rx.recv() => v,
+            _ = stop_rx.recv() => {
                 println!("received stop_rx");
-                match done_tx.send(()) {
-                    Ok(_) => println!("sent done_tx"),
-                    Err(e) => panic!("failed to sent done_tx {}", e),
-                }
                 break 'outer;
             }
-        }
+        };
 
-        match &req.echo_request {
+        match req.echo_request {
             Some(v) => match echo_manager.apply(&v) {
                 Ok(rs) => match notifier.trigger(req_id, rs) {
                     Ok(_) => {}

--- a/task-scheduler-rust/src/echo.rs
+++ b/task-scheduler-rust/src/echo.rs
@@ -3,34 +3,20 @@ use std::{
     io::{Error, ErrorKind},
 };
 
-use async_std::{sync::Arc, sync::RwLock};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Request {
     pub kind: String,
-    pub message: Option<String>,
-}
-
-impl Request {
-    pub fn new() -> Self {
-        Self {
-            kind: String::from(""),
-            message: None,
-        }
-    }
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
 }
 
 pub fn parse_request(b: &[u8]) -> io::Result<Request> {
-    let v: Request = match serde_json::from_slice(b) {
-        Ok(val) => val,
-        Err(e) => {
-            println!("failed to serde_json::from_slice {}", e);
-            return Err(Error::new(ErrorKind::InvalidInput, "invalid JSON"));
-        }
-    };
-    Ok(v)
+    serde_json::from_slice(b).map_err(|e| {
+        return Error::new(ErrorKind::InvalidInput, format!("invalid JSON: {}", e));
+    })
 }
 
 #[test]
@@ -38,60 +24,31 @@ fn test_parse_request() {
     let ret = parse_request("{\"kind\":\"create\",\"message\":\"hello\"}".as_bytes());
     assert!(ret.is_ok());
     let t = ret.unwrap();
-    assert!(t.kind.to_owned() == "create");
-    assert!(to_string(t.message.to_owned()) == "hello");
+    assert_eq!(t.kind, "create");
 }
 
 #[derive(Debug)]
-pub struct Manager {
-    mu: Arc<RwLock<()>>,
-}
+pub struct Manager {}
 
 impl Manager {
     pub fn new() -> Self {
-        Self {
-            mu: Arc::new(RwLock::new(())),
-        }
+        Self {}
     }
 
-    pub fn apply(&self, req: &Request) -> io::Result<String> {
+    pub fn apply(&mut self, req: &Request) -> io::Result<String> {
         println!("applying echo request");
-        let _mu;
-        match self.mu.try_write() {
-            Some(guard) => _mu = guard,
-            None => {
-                println!("failed to acquire lock");
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    "failed to acquire lock",
-                ));
-            }
-        }
 
         // check every 5-second
         // use std::{thread, time::Duration};
         // thread::sleep(Duration::from_secs(5));
 
         match req.kind.as_str() {
-            "create" => Ok(format!(
-                "SUCCESS create {}",
-                to_string(req.message.to_owned())
-            )),
-            "delete" => Ok(format!(
-                "SUCCESS delete {}",
-                to_string(req.message.to_owned())
-            )),
+            "create" => Ok(format!("SUCCESS create {}", req.message)),
+            "delete" => Ok(format!("SUCCESS delete {}", req.message)),
             _ => Err(Error::new(
                 ErrorKind::InvalidInput,
                 format!("unexpected none field value for kind {}", req.kind),
             )),
         }
-    }
-}
-
-fn to_string(o: Option<String>) -> String {
-    match o {
-        Some(v) => v,
-        None => String::new(),
     }
 }

--- a/task-scheduler-rust/src/notify.rs
+++ b/task-scheduler-rust/src/notify.rs
@@ -1,48 +1,46 @@
 use std::{
-    collections::HashMap,
+    collections::{hash_map::Entry, HashMap},
     io,
     io::{Error, ErrorKind},
     string::String,
+    sync::{Arc, Mutex},
 };
 
-use async_std::sync::RwLock;
-use crossbeam_channel::{self, unbounded};
+use tokio::sync::oneshot;
 
 #[derive(Debug)]
 pub struct Notifier {
-    requests: RwLock<HashMap<u64, crossbeam_channel::Sender<String>>>,
+    requests: Arc<Mutex<HashMap<u64, oneshot::Sender<String>>>>,
 }
 
 impl Notifier {
     pub fn new() -> Self {
         Self {
-            requests: RwLock::new(HashMap::new()),
+            requests: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    pub fn register(&self, id: u64) -> io::Result<crossbeam_channel::Receiver<String>> {
+    pub fn register(&self, id: u64) -> io::Result<oneshot::Receiver<String>> {
         println!("registering {}", id);
-        let mut _mu;
-        match self.requests.try_write() {
-            Some(guard) => _mu = guard,
-            None => {
-                println!("failed to acquire lock");
+
+        let (request_tx, request_rx) = oneshot::channel();
+
+        let mut locked_map = self
+            .requests
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "failed to acquire lock"))?;
+
+        match locked_map.entry(id) {
+            Entry::Vacant(entry) => {
+                entry.insert(request_tx);
+            }
+            Entry::Occupied(_) => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    "failed to acquire lock",
-                ));
+                    format!("duplicate request ID {}", id),
+                ))
             }
-        }
-
-        let (request_tx, request_rx) = unbounded();
-        if _mu.get(&id).is_none() {
-            _mu.insert(id, request_tx);
-        } else {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                format!("duplicate request ID {}", id),
-            ));
-        }
+        };
 
         println!("registered {}", id);
         Ok(request_rx)
@@ -50,38 +48,24 @@ impl Notifier {
 
     pub fn trigger(&self, id: u64, x: String) -> io::Result<()> {
         println!("triggering {}", id);
-        let mut _mu;
-        match self.requests.try_write() {
-            Some(guard) => _mu = guard,
-            None => {
-                println!("failed to acquire lock");
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    "failed to acquire lock",
-                ));
-            }
-        }
 
-        let request_tx;
-        match _mu.get(&id) {
-            Some(ch) => request_tx = ch,
-            None => {
+        let mut locked_map = self
+            .requests
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "failed to acquire lock"))?;
+
+        match locked_map.entry(id) {
+            Entry::Occupied(entry) => {
+                println!("triggered {}", &id);
+                let request_tx = entry.remove();
+                request_tx.send(x).map_err(|e| {
+                    Error::new(ErrorKind::Other, format!("failed to send {} {}", id, e))
+                })?;
+            }
+            Entry::Vacant(_) => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
                     format!("unknown request ID {}", id),
-                ))
-            }
-        }
-
-        match request_tx.send(x) {
-            Ok(_) => {
-                println!("triggered {}", &id);
-                _mu.remove(&id);
-            }
-            Err(e) => {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("failed to send {} {}", id, e),
                 ))
             }
         }
@@ -90,27 +74,25 @@ impl Notifier {
     }
 }
 
-#[test]
-fn test_wait() {
+#[tokio::test]
+async fn test_wait() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+    use uuid::Uuid;
+
     let notifier = Notifier::new();
 
     let ret = notifier.register(100);
     assert!(ret.is_ok());
     let rx = ret.unwrap();
 
-    use uuid::Uuid;
     let uuid = Uuid::new_v4().to_hyphenated().to_string();
 
     let tr = notifier.trigger(100, uuid.clone());
     assert!(tr.is_ok());
 
-    use crossbeam_channel::{after, select};
-    use std::time::Duration;
-    let timeout = after(Duration::from_secs(1));
-    select! {
-        recv(rx) -> msg => assert_eq!(msg, Ok(uuid.clone())),
-        recv(timeout) -> _ => panic!("timed out"),
-    }
+    let msg = timeout(Duration::from_secs(1), rx).await;
+    assert_eq!(msg, Ok(Ok(uuid.clone())));
 
     let tr = notifier.trigger(100, uuid);
     assert!(!tr.is_ok());


### PR DESCRIPTION
More idiomatic Rust :)


Split channel sender and receiver into two clear owners.

Replace sync crossbeam with async tokio channels, so we don't hold a
synchronous lock over async await.

Simplify applier start/stop lifecycle with RAII pattern (could do more here).

Pass owned `echo::Manager` to `apply_async` rather than `Arc` reference.

Use `?` operator and early-return to refactor some deeply nested code,
particularly in `server::handle_request`.

`Notifier`: Replace async `RwLock<>` with simpler sync `Arc<Mutex<>>`
because these locks don't need to be held over async await.

`echo::Manager`: Use ownership (`&mut`) to assert mutual exclusion
rather than a lock.

`echo::Request`: Treat omitted `message` as equivalent to
`message == ""`, to better match golang `omitempty` semantics.
